### PR TITLE
Bugfix: ABI error + lossy BigInt formatting

### DIFF
--- a/lib/src/embedded/definitions.dart
+++ b/lib/src/embedded/definitions.dart
@@ -114,9 +114,7 @@ class Definitions {
     {"type":"function","name":"Update","inputs":[]},
     {"type":"function","name":"Donate","inputs":[]},
     {"type":"function","name":"VoteByName","inputs":[{"name":"id","type":"hash"},{"name":"name","type":"string"},{"name":"vote","type":"uint8"}]},
-    {"type":"function","name":"VoteByProdAddress","inputs":[{"name":"id","type":"hash"},{"name":"vote","type":"uint8"}]},
-    {"type":"variable","name":"timeChallengeInfo","inputs":[{"name":"methodName","type":"string"},{"name":"paramsHash","type":"hash"},{"name":"challengeStartHeight","type":"uint64"}]},
-    {"type":"variable","name":"securityInfo","inputs":[{"name":"guardians","type":"address[]"},{"name":"guardiansVotes","type":"address[]"},{"name":"administratorDelay","type":"uint64"},{"name":"softDelay","type":"uint64"}]}
+    {"type":"function","name":"VoteByProdAddress","inputs":[{"name":"id","type":"hash"},{"name":"vote","type":"uint8"}]}
   ]''';
 
   // ABI definitions of embedded contracts

--- a/lib/src/utils/amount.dart
+++ b/lib/src/utils/amount.dart
@@ -2,8 +2,17 @@ import 'package:big_decimal/big_decimal.dart';
 
 class AmountUtils {
   // This methods removes decimals and returns a BigInt
-  static BigInt extractDecimals(num num, int decimals) =>
-      BigInt.parse(num.toStringAsFixed(decimals).replaceAll('.', ''));
+  static BigInt extractDecimals(String amount, int decimals) {
+    if (!amount.contains('.')) {
+      return BigInt.parse(amount + ''.padRight(decimals, '0'));
+    }
+    List<String> parts = amount.split('.');
+
+    return BigInt.parse(parts[0] +
+        (parts[1].length > decimals
+            ? parts[1].substring(0, decimals)
+            : parts[1].padRight(decimals, '0')));
+  }
 
   static String addDecimals(BigInt number, int decimals) {
     return BigDecimal.createAndStripZerosForScale(number, decimals, 0)


### PR DESCRIPTION
Recently encountered an issue when attempting to call a Common ABI function.

Example: ```Error while depositing QSR for Sentinel: Zenon SDK Exception: Only ABI functions supported```

The Dart SDK throws an error if there are `variable` entries in the definitions. 
Removing these two lines corrected the problem.

--------

Additional bugfix: BigInt formatting was lossy when dealing with extremely large `int` due to type conversion to 'num'.