### PR TITLE
[bugfix] ABI encoding discrepancy for SetTokenTuple

### DIFF
--- a/lib/src/abi/abi_types.dart
+++ b/lib/src/abi/abi_types.dart
@@ -94,8 +94,8 @@ abstract class ArrayType extends AbiType {
         elems[i] = IntType.encodeInt(offset);
         List<int> encoded = elementType.encode(l[i]);
         elems[l.length + i] = encoded;
-        offset += (AbiType.int32Size *
-            ((encoded.length - 1) / AbiType.int32Size + 1)) as int;
+        offset +=
+            (AbiType.int32Size * (encoded.length / AbiType.int32Size)).toInt();
       }
     } else {
       elems = List<List<int>>.filled(l.length, [], growable: true);

--- a/lib/src/api/embedded/liquidity.dart
+++ b/lib/src/api/embedded/liquidity.dart
@@ -88,7 +88,7 @@ class LiquidityApi {
       List<String> tokenStandards,
       List<int> znnPercentages,
       List<int> qsrPercentages,
-      List<int> minAmounts) {
+      List<BigInt> minAmounts) {
     return AccountBlockTemplate.callContract(
         liquidityAddress,
         znnZts,


### PR DESCRIPTION
This PR resolves the ABI discrepancies that prevented calls to SetTokenTuple() from succeeding.

Issue: https://github.com/hypercore-one/znn_sdk_dart/issues/11
Similar to https://github.com/hypercore-one/znn_sdk_dart/pull/10
Confirmation: [tx](https://zenonhub.io/explorer/transaction/1c37bd958f917e5488c95cfe7150fe3a729b5baac030f80bd0aee95851bd3ea3)

The function will be re-instated in znn-cli after this patch is merged.
